### PR TITLE
Update command-line option pss uses instead of -H

### DIFF
--- a/plugin/pss.vim
+++ b/plugin/pss.vim
@@ -3,7 +3,7 @@
 
 " Location of the pss utility
 if !exists("g:pssprg")
-	let g:pssprg="pss -H --nocolor --column --noheading --nobreak"
+	let g:pssprg="pss --with-filename --nocolor --column --noheading --nobreak"
 endif
 
 function! s:Pss(cmd, args)


### PR DESCRIPTION
-H was removed a while ago to avoid confusion with other "h"-like options. This makes the plugin work with modern pss